### PR TITLE
Show affiliate last_name and first_name as separate fields (#61)

### DIFF
--- a/road_union_economic_management/models/pharmacies.py
+++ b/road_union_economic_management/models/pharmacies.py
@@ -45,6 +45,8 @@ class AffiliatePharmacyExpenses(models.Model):
     _description = "Gastos mensuales por farmacia"
 
     affiliate_id = fields.Many2one("affiliation.affiliate", string="Afiliado", required=True)
+    affiliate_last_name = fields.Char(related='affiliate_id.last_name', string='Apellido', store=True, readonly=True)
+    affiliate_first_name = fields.Char(related='affiliate_id.first_name', string='Nombre', store=True, readonly=True)
     month = fields.Selection([
         ('01', 'Enero'),
         ('02', 'Febrero'),

--- a/road_union_economic_management/views/pharmacies_views.xml
+++ b/road_union_economic_management/views/pharmacies_views.xml
@@ -19,6 +19,8 @@
                     <group>
                         <group>
                             <field name="affiliate_id" options="{'no_create': True, 'no_create_edit': True}"/>
+                            <field name="affiliate_last_name" readonly="1"/>
+                            <field name="affiliate_first_name" readonly="1"/>
                             <field name="year"/>
                             <field name="month"/>
                         </group>
@@ -57,9 +59,10 @@
         <field name="name">affiliate.pharmacy.expenses.tree</field>
         <field name="model">affiliate.pharmacy.expenses</field>
         <field name="arch" type="xml">
-            <tree string="Gastos Mensuales Farmacia" 
+            <tree string="Gastos Mensuales Farmacia"
                   default_order="year desc, month desc">
-                <field name="affiliate_id"/>
+                <field name="affiliate_last_name"/>
+                <field name="affiliate_first_name"/>
                 <field name="year"/>
                 <field name="month"/>
                 <field name="suma_mes" sum="Total"/>


### PR DESCRIPTION
## Summary

- Agrega campos related `affiliate_last_name` y `affiliate_first_name` en el modelo de gastos de farmacia
- Muestra Apellido y Nombre como columnas separadas en el tree de Gastos Mensuales Farmacia
- Muestra ambos campos en el form debajo del selector de afiliado

## Test plan

- [ ] Ir a Gastos Farmacia Mensuales y verificar que se ven las columnas Apellido y Nombre separadas
- [ ] Abrir un registro y verificar que en el form aparecen Apellido y Nombre como campos readonly