### PR TITLE
Add sticky header and name column to affiliate list views

### DIFF
--- a/road_union_affiliation/__manifest__.py
+++ b/road_union_affiliation/__manifest__.py
@@ -10,6 +10,11 @@
     'version': '1.0',
     "license": "AGPL-3",
     'depends': ['base', 'union_affiliation'],
+    'assets': {
+        'web.assets_backend': [
+            'road_union_affiliation/static/src/scss/list_sticky.scss',
+        ],
+    },
     'data': [
         'views/affiliate_views.xml',
         'views/insurance_views.xml',

--- a/road_union_affiliation/static/src/scss/list_sticky.scss
+++ b/road_union_affiliation/static/src/scss/list_sticky.scss
@@ -1,0 +1,71 @@
+// Sticky header + first column for specific list views
+// Applied via class="o_sticky_list" on <tree> elements
+// Sticky columns: checkbox (1) + name (2)
+
+.o_sticky_list {
+    overflow: auto !important;
+    max-height: calc(100vh - 195px);
+
+    .o_list_table {
+        border-collapse: separate !important;
+        border-spacing: 0;
+
+        // Sticky header
+        thead th {
+            position: sticky !important;
+            top: 0;
+            z-index: 2;
+            background-color: #edf0f5;
+        }
+
+        // Sticky col 1: checkbox
+        th:nth-child(1),
+        td:nth-child(1) {
+            position: sticky !important;
+            left: 0;
+            z-index: 1;
+        }
+
+        // Sticky col 2: name
+        th:nth-child(2),
+        td:nth-child(2) {
+            position: sticky !important;
+            left: 40px;
+            z-index: 1;
+        }
+
+        // Header corners: sticky both axes
+        thead th:nth-child(1),
+        thead th:nth-child(2) {
+            z-index: 4;
+            background-color: #edf0f5 !important;
+        }
+
+        // Solid backgrounds on sticky data cells
+        tbody td:nth-child(1),
+        tbody td:nth-child(2) {
+            background-color: #ffffff;
+        }
+        tbody tr:nth-child(even) td:nth-child(1),
+        tbody tr:nth-child(even) td:nth-child(2) {
+            background-color: #f9f9f9;
+        }
+        tbody tr:hover td:nth-child(1),
+        tbody tr:hover td:nth-child(2) {
+            background-color: #e8e8e8;
+        }
+
+        // Row backgrounds
+        tbody tr {
+            background-color: #ffffff;
+            &:nth-child(even) { background-color: #f9f9f9; }
+            &:hover { background-color: #e8e8e8; }
+        }
+
+        // Shadow on last sticky column edge
+        th:nth-child(2),
+        td:nth-child(2) {
+            box-shadow: 2px 0 4px -2px rgba(0, 0, 0, 0.15);
+        }
+    }
+}

--- a/road_union_affiliation/views/affiliate_child_readonly_views.xml
+++ b/road_union_affiliation/views/affiliate_child_readonly_views.xml
@@ -5,7 +5,7 @@
         <field name="model">affiliation.affiliate_child</field>
         <field name="priority" eval="100"/>
         <field name="arch" type="xml">
-            <tree>
+            <tree class="o_sticky_list">
                 <field name="name"/>
                 <field name="age"/>
                 <field name="personal_id"/>

--- a/road_union_affiliation/views/affiliate_old_db_views.xml
+++ b/road_union_affiliation/views/affiliate_old_db_views.xml
@@ -3,12 +3,12 @@
         <field name="name">affiliation.affiliate.tree</field>
         <field name="model">affiliation.affiliate</field>
         <field name="arch" type="xml">
-            <tree>
+            <tree class="o_sticky_list">
+                <field name="name" string="Apellido y Nombre"/>
                 <field name="gender"/>
                 <field name="department_id"/>
                 <field name="affiliate_type_id"/>
                 <field name="insurance_id"/>
-                <field name="name"/>
                 <field name="uid"/>
                 <field name="street"/>
                 <field name="city"/>


### PR DESCRIPTION
## Summary
- Add SCSS for sticky thead and first column (checkbox + name) in affiliate and children tree views
- Reorder name as first column and rename to "Apellido y Nombre"
- Scoped via `o_sticky_list` class so other list views are not affected

Closes #63