### PR TITLE
Fix footer totals + sticky columns in economic views

### DIFF
--- a/road_union_economic_management/__manifest__.py
+++ b/road_union_economic_management/__manifest__.py
@@ -9,9 +9,14 @@
     'category': 'Union',
     'version': '1.0',
     "license": "AGPL-3",
-    'depends': ['base', 'base_automation', 
-                'union_affiliation', 'road_union_affiliation', 
+    'depends': ['base', 'base_automation',
+                'union_affiliation', 'road_union_affiliation',
                 'web_widget_x2many_2d_matrix'],
+    'assets': {
+        'web.assets_backend': [
+            'road_union_economic_management/static/src/js/list_server_aggregates.js',
+        ],
+    },
     'data': [
         'views/affiliate_class_basic_views.xml',
         'views/payment_account_current_views.xml',

--- a/road_union_economic_management/models/payment_account.py
+++ b/road_union_economic_management/models/payment_account.py
@@ -139,7 +139,7 @@ class AffiliatePaymentAccount(models.Model):
         compute='_compute_initial_balance',
         inverse='_inverse_initial_balance',
         store=True,
-        group_operator=False,
+        group_operator='sum',
         help="Saldo inicial del mes. Se calcula automáticamente del mes anterior si existe, "
              "o puede ingresarse manualmente si es el primer mes del afiliado."
     )
@@ -198,48 +198,48 @@ class AffiliatePaymentAccount(models.Model):
                 record._compute_initial_balance()
 
     # Service Totals
-    pharmacy_total = fields.Float(string="Todas las farmacias", group_operator=False)
+    pharmacy_total = fields.Float(string="Todas las farmacias", group_operator='sum')
     pharmacy_installment = fields.Char(string="N° Cuota Farmacias")
 
-    optical_total = fields.Float(string="Optica", group_operator=False)
+    optical_total = fields.Float(string="Optica", group_operator='sum')
     odontology_installment = fields.Char(string="N° Cuota Odontología")
     
-    punilla_total = fields.Float(string="Punilla", group_operator=False)
+    punilla_total = fields.Float(string="Punilla", group_operator='sum')
 
-    solar = fields.Float(string="Solar", group_operator=False)
-    caruso = fields.Float(string="Caruso", group_operator=False)
-    
-    parque_del_sol = fields.Float(string="Parque del Sol", group_operator=False)
-    salguero = fields.Float(string="Salguero", group_operator=False)
-    tres_provincias = fields.Float(string="Tres Provincias", group_operator=False)
+    solar = fields.Float(string="Solar", group_operator='sum')
+    caruso = fields.Float(string="Caruso", group_operator='sum')
 
-    ecco_loan = fields.Float(string="ECCO", group_operator=False)
-    emi_loan = fields.Float(string="EMI", group_operator=False)
-    emergency_loan = fields.Float(string="URGENCIAS", group_operator=False)
-    suoem_loan = fields.Float(string="SUOEM", group_operator=False)
+    parque_del_sol = fields.Float(string="Parque del Sol", group_operator='sum')
+    salguero = fields.Float(string="Salguero", group_operator='sum')
+    tres_provincias = fields.Float(string="Tres Provincias", group_operator='sum')
 
-    tourism_total = fields.Float(string="Turismo", group_operator=False)
+    ecco_loan = fields.Float(string="ECCO", group_operator='sum')
+    emi_loan = fields.Float(string="EMI", group_operator='sum')
+    emergency_loan = fields.Float(string="URGENCIAS", group_operator='sum')
+    suoem_loan = fields.Float(string="SUOEM", group_operator='sum')
+
+    tourism_total = fields.Float(string="Turismo", group_operator='sum')
     tourism_installment = fields.Char(string="N° Cuota Turismo")
 
-    aid_total = fields.Float(string="AYUDA SOLIDARIA", group_operator=False)
+    aid_total = fields.Float(string="AYUDA SOLIDARIA", group_operator='sum')
     aid_installment = fields.Char(string="N° Cuota Ayudas")
 
-    party_total = fields.Float(string="FIESTA", group_operator=False)
+    party_total = fields.Float(string="FIESTA", group_operator='sum')
     party_installment = fields.Char(string="N° Cuota Fiesta")
 
-    hall_total = fields.Float(string="Salon", group_operator=False)
+    hall_total = fields.Float(string="Salon", group_operator='sum')
     hall_installment = fields.Char(string="N° Cuota Salón")
 
-    odontology_total = fields.Float(string="Odontología", group_operator=False)
+    odontology_total = fields.Float(string="Odontología", group_operator='sum')
 
-    otros_1 = fields.Float(string="OTROS 1", group_operator=False)
-    otros_2 = fields.Float(string="OTROS 2", group_operator=False)
+    otros_1 = fields.Float(string="OTROS 1", group_operator='sum')
+    otros_2 = fields.Float(string="OTROS 2", group_operator='sum')
 
     union_fee = fields.Float(
         string="CUOTA SINDICAL",
         compute='_compute_union_fee',
         store=True,
-        group_operator=False,
+        group_operator='sum',
         help="Calculado automáticamente según clase y tipo de afiliado"
     )
 
@@ -288,28 +288,28 @@ class AffiliatePaymentAccount(models.Model):
                 record.union_fee = record.union_fee * 0.75
 
     total_services = fields.Float(
-        string="TOTAL SERVICIOS", 
+        string="TOTAL SERVICIOS",
         compute='_compute_total_services',
         store=True,
-        group_operator=False
+        group_operator='sum'
     )
 
     total = fields.Float(
-        string="TOTAL", 
+        string="TOTAL",
         compute='_compute_total',
         store=True,
-        group_operator=False
+        group_operator='sum'
     )
-    
-    payments = fields.Float(string="Pagos", group_operator=False)
-    pension_fund = fields.Float(string="CAJA DE JUBILACIONES", group_operator=False)
-    meta4 = fields.Float(string="META 4", group_operator=False)
-    
+
+    payments = fields.Float(string="Pagos", group_operator='sum')
+    pension_fund = fields.Float(string="CAJA DE JUBILACIONES", group_operator='sum')
+    meta4 = fields.Float(string="META 4", group_operator='sum')
+
     final_balance = fields.Float(
-        string="SALDO", 
+        string="SALDO",
         compute='_compute_final_balance',
         store=True,
-        group_operator=False
+        group_operator='sum'
     )
 
     state = fields.Selection([

--- a/road_union_economic_management/static/src/js/list_server_aggregates.js
+++ b/road_union_economic_management/static/src/js/list_server_aggregates.js
@@ -1,0 +1,116 @@
+/** @odoo-module */
+
+import { patch } from "@web/core/utils/patch";
+import { DynamicRecordList } from "@web/views/relational_model";
+import { ListRenderer } from "@web/views/list/list_renderer";
+import { registry } from "@web/core/registry";
+
+const AGGREGATABLE_FIELD_TYPES = ["float", "integer", "monetary"];
+const formatters = registry.category("formatters");
+
+/**
+ * Patch DynamicRecordList to fetch server-side aggregates via read_group
+ * when the list has more records than the visible page.
+ */
+patch(DynamicRecordList.prototype, "server_side_aggregates_model", {
+    async _loadRecords() {
+        const records = await this._super(...arguments);
+        await this._fetchServerAggregates();
+        return records;
+    },
+
+    async _fetchServerAggregates() {
+        this._serverAggregates = null;
+
+        // Only fetch server aggregates if paginated (more records than visible)
+        if (this.count <= this.records.length) {
+            return;
+        }
+
+        // Find fields that need aggregation (have sum/avg in the view AND group_operator in the model)
+        const aggregateFields = [];
+        for (const fieldName in this.activeFields) {
+            const field = this.fields[fieldName];
+            if (!field || !AGGREGATABLE_FIELD_TYPES.includes(field.type)) {
+                continue;
+            }
+            if (!field.group_operator) {
+                continue;
+            }
+            const rawAttrs = this.activeFields[fieldName].rawAttrs || {};
+            if (rawAttrs.sum || rawAttrs.avg) {
+                aggregateFields.push(fieldName);
+            }
+        }
+
+        if (!aggregateFields.length) {
+            return;
+        }
+
+        try {
+            const result = await this.model.orm.readGroup(
+                this.resModel,
+                this.domain,
+                aggregateFields,
+                [],
+                { context: this.context }
+            );
+            if (result && result.length) {
+                this._serverAggregates = {};
+                for (const fieldName of aggregateFields) {
+                    if (fieldName in result[0]) {
+                        this._serverAggregates[fieldName] = result[0][fieldName] || 0;
+                    }
+                }
+            }
+        } catch (e) {
+            // Silently fail — fall back to client-side aggregation
+            this._serverAggregates = null;
+        }
+    },
+});
+
+/**
+ * Patch ListRenderer to use server-side aggregates when available
+ * instead of computing from the visible page records.
+ */
+patch(ListRenderer.prototype, "server_side_aggregates_renderer", {
+    get aggregates() {
+        const list = this.props.list;
+
+        // Use server aggregates only for ungrouped lists with no active selection
+        if (
+            !list.isGrouped &&
+            !(list.selection && list.selection.length) &&
+            list._serverAggregates
+        ) {
+            const aggregates = {};
+            for (const fieldName in list.activeFields) {
+                if (!(fieldName in list._serverAggregates)) {
+                    continue;
+                }
+                const field = this.fields[fieldName];
+                const { rawAttrs, widget } = list.activeFields[fieldName];
+                const func =
+                    (rawAttrs.sum && "sum") || (rawAttrs.avg && "avg");
+                if (!func) {
+                    continue;
+                }
+                const value = list._serverAggregates[fieldName];
+                const type = field.type;
+                const formatter = formatters.get(widget, false) || formatters.get(type, false);
+                const formatOptions = {
+                    digits: rawAttrs.digits ? JSON.parse(rawAttrs.digits) : undefined,
+                    escape: true,
+                };
+                aggregates[fieldName] = {
+                    help: rawAttrs[func],
+                    value: formatter ? formatter(value, formatOptions) : value,
+                };
+            }
+            return aggregates;
+        }
+
+        return this._super();
+    },
+});

--- a/road_union_economic_management/views/payment_account_current_views.xml
+++ b/road_union_economic_management/views/payment_account_current_views.xml
@@ -8,13 +8,13 @@
         <field name="model">affiliate.payment_account</field>
         <field name="priority" eval="10"/>
         <field name="arch" type="xml">
-            <tree editable="bottom" import="true">
+            <tree editable="bottom" import="true" class="o_sticky_list">
                 <!-- Campo helper oculto -->
                 <field name="has_previous_month" invisible="1"/>
-                
+
                 <!-- Información del Afiliado -->
-                <field name="affiliate_type"/>
                 <field name="affiliate_name"/>
+                <field name="affiliate_type"/>
                 <field name="affiliate_class"/>
                 <field name="affiliate_number"/>
                 <field name="cuil"/>
@@ -86,7 +86,7 @@
       <field name="name">affiliate.payment_account.tree.grouped</field>
       <field name="model">affiliate.payment_account</field>
       <field name="arch" type="xml">
-        <tree import="true">
+        <tree import="true" class="o_sticky_list">
           <!-- Información del Afiliado -->
           <field name="affiliate_name"/>
           <field name="affiliate_class"/>
@@ -173,16 +173,16 @@
         <field name="model">affiliate.payment_account</field>
         <field name="priority" eval="5"/>
         <field name="arch" type="xml">
-            <tree editable="bottom" delete="true" decoration-info="state == 'draft'" decoration-success="state == 'confirmed'">
+            <tree editable="bottom" delete="true" decoration-info="state == 'draft'" decoration-success="state == 'confirmed'" class="o_sticky_list">
                 <!-- Campo helper oculto PRIMERO -->
                 <field name="has_previous_month" invisible="1"/>
-                
+
                 <!-- SECCIÓN: Información del Afiliado -->
+                <field name="affiliate_name"/>
                 <field name="id"/>
                 <field name="affiliate_id"/>
 
                 <field name="affiliate_type"/>
-                <field name="affiliate_name"/>
                 <field name="affiliate_class"/>
                 <field name="affiliate_number"/>
                 <field name="cuil"/>

--- a/road_union_economic_management/views/pharmacies_views.xml
+++ b/road_union_economic_management/views/pharmacies_views.xml
@@ -60,7 +60,8 @@
         <field name="model">affiliate.pharmacy.expenses</field>
         <field name="arch" type="xml">
             <tree string="Gastos Mensuales Farmacia"
-                  default_order="year desc, month desc">
+                  default_order="year desc, month desc"
+                  class="o_sticky_list">
                 <field name="affiliate_last_name"/>
                 <field name="affiliate_first_name"/>
                 <field name="year"/>


### PR DESCRIPTION
## Summary
- Fix footer totals in "Resúmenes Económicos" to sum ALL filtered records instead of only the visible page
- Change `group_operator=False` to `group_operator='sum'` on all Float fields in `payment_account` model
- Add JS override of `ListRenderer` to fetch server-side aggregates via `read_group` when paginated (Odoo 16 CE limitation fix)
- Add `o_sticky_list` class to economic summary and pharmacy tree views
- Move `affiliate_name` as first visible column for sticky behavior

## Test plan
- [ ] Open "Resúmenes Económicos", remove month filter so all records show
- [ ] Verify footer totals sum ALL records, not just the 80 visible on current page
- [ ] Scroll horizontally — affiliate name column stays fixed
- [ ] Scroll vertically — headers stay fixed
- [ ] Open "Gastos de Farmacia" and verify sticky works

Closes #64