### PR TITLE
Add affiliate UID to children views and import

### DIFF
--- a/road_union_affiliation/models/affiliate_child.py
+++ b/road_union_affiliation/models/affiliate_child.py
@@ -14,12 +14,32 @@ class AffiliateChild(models.Model):
         help="Age calculated from birth date"
     )
     
-    # Campo helper para importación
+    # Campo computado para mostrar UIDs de los padres
+    affiliate_uids = fields.Char(
+        string='N° Afiliado (Padres)',
+        compute='_compute_affiliate_uids',
+        store=True,
+    )
+
+    # Campo helper para importación por nombre
     affiliate_parent_name = fields.Char(
         string='Nombre del Padre/Madre (para importación)',
         help='Campo auxiliar para facilitar la importación. Ingrese el nombre exacto del afiliado.'
     )
+
+    # Campo helper para importación por UID
+    affiliate_parent_uid = fields.Integer(
+        string='N° Afiliado del Padre/Madre (para importación)',
+        help='Campo auxiliar para facilitar la importación. Ingrese el número de afiliado.'
+    )
     
+    @api.depends('affiliate_ids.uid')
+    def _compute_affiliate_uids(self):
+        for record in self:
+            record.affiliate_uids = ', '.join(
+                str(uid) for uid in record.affiliate_ids.mapped('uid') if uid
+            )
+
     @api.depends('birth_date')
     def _compute_age(self):
         """Calcula la edad en años basada en la fecha de nacimiento"""
@@ -41,7 +61,18 @@ class AffiliateChild(models.Model):
     
     @api.model
     def create(self, vals):
-        """Override para procesar affiliate_parent_name en importación"""
+        """Override para procesar affiliate_parent_name y affiliate_parent_uid en importación"""
+        if 'affiliate_parent_uid' in vals and vals['affiliate_parent_uid']:
+            parent_uid = vals.pop('affiliate_parent_uid')
+            affiliate = self.env['affiliation.affiliate'].search([
+                ('uid', '=', int(parent_uid))
+            ], limit=1)
+            if affiliate:
+                if 'affiliate_ids' not in vals:
+                    vals['affiliate_ids'] = []
+                vals['affiliate_ids'] = [(4, affiliate.id)]
+                self._update_parent_role(affiliate)
+
         if 'affiliate_parent_name' in vals and vals['affiliate_parent_name']:
             parent_name = vals.pop('affiliate_parent_name')
             affiliate = self.env['affiliation.affiliate'].search([
@@ -51,8 +82,6 @@ class AffiliateChild(models.Model):
                 if 'affiliate_ids' not in vals:
                     vals['affiliate_ids'] = []
                 vals['affiliate_ids'] = [(4, affiliate.id)]
-                
-                # Actualizar parent_role según el género del afiliado
                 self._update_parent_role(affiliate)
         
         # Crear el registro del hijo

--- a/road_union_affiliation/views/affiliate_child_readonly_views.xml
+++ b/road_union_affiliation/views/affiliate_child_readonly_views.xml
@@ -14,6 +14,7 @@
                 <field name="verified"/>
                 <field name="educational_level"/>
                 <field name="observation"/>
+                <field name="affiliate_uids"/>
                 <field name="affiliate_names"/>
             </tree>
         </field>
@@ -34,6 +35,7 @@
                         <field name="handicapped"/>
                         <field name="verified"/>
                         <field name="educational_level"/>
+                        <field name="affiliate_uids"/>
                         <field name="affiliate_names"/>
                         <field name="observation"/>
                     </group>


### PR DESCRIPTION
## Summary
- Add computed field `affiliate_uids` showing parent affiliate numbers in children tree/form views
- Add `affiliate_parent_uid` helper field for CSV import (associate child to parent by affiliate number)
- Display "N° Afiliado (Padres)" column in children readonly views and exports

## Test plan
- [x] Open "Affiliate's Childs" view — verify new column shows parent UIDs
- [x] Open a child form — verify UID field is visible
- [x] Export all from children tree — verify UID column is included in export
- [x] Import a child CSV using `affiliate_parent_uid` column — verify parent association works

Closes #68