### PR TITLE
Add parent department fields to children views and export

### DIFF
--- a/road_union_affiliation/models/affiliate_child.py
+++ b/road_union_affiliation/models/affiliate_child.py
@@ -21,6 +21,18 @@ class AffiliateChild(models.Model):
         store=True,
     )
 
+    # Departamentos de los padres (1 y 2)
+    affiliate_department_1 = fields.Char(
+        string='Departamento 1',
+        compute='_compute_affiliate_departments',
+        store=True,
+    )
+    affiliate_department_2 = fields.Char(
+        string='Departamento 2',
+        compute='_compute_affiliate_departments',
+        store=True,
+    )
+
     # Campo helper para importación por nombre
     affiliate_parent_name = fields.Char(
         string='Nombre del Padre/Madre (para importación)',
@@ -33,6 +45,13 @@ class AffiliateChild(models.Model):
         help='Campo auxiliar para facilitar la importación. Ingrese el número de afiliado.'
     )
     
+    @api.depends('affiliate_ids.department_id')
+    def _compute_affiliate_departments(self):
+        for record in self:
+            parents = record.affiliate_ids
+            record.affiliate_department_1 = parents[0].department_id.name if len(parents) > 0 and parents[0].department_id else ''
+            record.affiliate_department_2 = parents[1].department_id.name if len(parents) > 1 and parents[1].department_id else ''
+
     @api.depends('affiliate_ids.uid')
     def _compute_affiliate_uids(self):
         for record in self:

--- a/road_union_affiliation/views/affiliate_child_readonly_views.xml
+++ b/road_union_affiliation/views/affiliate_child_readonly_views.xml
@@ -16,6 +16,8 @@
                 <field name="observation"/>
                 <field name="affiliate_uids"/>
                 <field name="affiliate_names"/>
+                <field name="affiliate_department_1"/>
+                <field name="affiliate_department_2"/>
             </tree>
         </field>
     </record>
@@ -37,6 +39,8 @@
                         <field name="educational_level"/>
                         <field name="affiliate_uids"/>
                         <field name="affiliate_names"/>
+                        <field name="affiliate_department_1"/>
+                        <field name="affiliate_department_2"/>
                         <field name="observation"/>
                     </group>
                 </sheet>


### PR DESCRIPTION
## Summary
- Add computed fields `affiliate_department_1` and `affiliate_department_2` to children model
- Display parent departments in children tree and form views
- Department 2 is optional (empty when child has only one parent)
- Stored fields so they are included in Odoo native "Export All"

## Test plan
- [x] Open "Affiliate's Childs" view — verify Departamento 1 and 2 columns appear
- [x] Verify department shows correctly for children with one parent
- [x] Verify both departments show for children with two parents
- [x] Export all — verify department columns are in the export file

Closes #69