### PR TITLE
Add monthly class basic history with controlled propagation

### DIFF
--- a/road_union_economic_management/__init__.py
+++ b/road_union_economic_management/__init__.py
@@ -1,1 +1,56 @@
 from . import models, wizards
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def _post_init_hook(cr, registry):
+    """
+    Migración: crea registros de historial para todos los meses existentes
+    usando los básicos actuales de cada clase.
+    """
+    from odoo import api, SUPERUSER_ID
+
+    env = api.Environment(cr, SUPERUSER_ID, {})
+
+    History = env['affiliate.class.basic.history']
+    ClassBasic = env['affiliate.class.basic']
+    PaymentAccount = env['affiliate.payment_account']
+
+    all_classes = ClassBasic.search([], order='class_number asc')
+    if not all_classes:
+        return
+
+    # Obtener meses/años distintos de payment_account
+    cr.execute("""
+        SELECT DISTINCT date_month, date_year
+        FROM affiliate_payment_account
+        ORDER BY date_year, date_month
+    """)
+    months = cr.fetchall()
+
+    if not months:
+        return
+
+    _logger.info(f"post_init_hook: Creating history for {len(months)} months and {len(all_classes)} classes")
+
+    first_month = True
+    for date_month, date_year in months:
+        for class_basic in all_classes:
+            existing = History.search([
+                ('class_basic_id', '=', class_basic.id),
+                ('date_month', '=', date_month),
+                ('date_year', '=', date_year),
+            ], limit=1)
+
+            if not existing:
+                History.create({
+                    'class_basic_id': class_basic.id,
+                    'date_month': date_month,
+                    'date_year': date_year,
+                    'basic_amount': class_basic.basic_amount,
+                    'manually_modified': first_month and class_basic.class_number == 1,
+                })
+        first_month = False
+
+    _logger.info("post_init_hook: History records created successfully")

--- a/road_union_economic_management/__manifest__.py
+++ b/road_union_economic_management/__manifest__.py
@@ -17,8 +17,10 @@
             'road_union_economic_management/static/src/js/list_server_aggregates.js',
         ],
     },
+    'post_init_hook': '_post_init_hook',
     'data': [
         'views/affiliate_class_basic_views.xml',
+        'views/affiliate_class_basic_history_views.xml',
         'views/payment_account_current_views.xml',
         'security/ir.model.access.csv',
         'views/affiliate_views.xml',

--- a/road_union_economic_management/models/__init__.py
+++ b/road_union_economic_management/models/__init__.py
@@ -1,1 +1,1 @@
-from . import affiliate, payment_account, provider_payments, pharmacies, installment_plan
+from . import affiliate, payment_account, provider_payments, pharmacies, installment_plan, class_basic_history

--- a/road_union_economic_management/models/class_basic_history.py
+++ b/road_union_economic_management/models/class_basic_history.py
@@ -1,0 +1,358 @@
+from odoo import models, fields, api
+from datetime import datetime
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+class AffiliateClassBasicHistory(models.Model):
+    _name = "affiliate.class.basic.history"
+    _description = "Monthly History of Basic Amounts by Class"
+    _order = "date_year desc, date_month desc, class_number asc"
+
+    def _default_class_basic_id(self):
+        return self.env['affiliate.class.basic'].search(
+            [('class_number', '=', 1)], limit=1).id
+
+    class_basic_id = fields.Many2one(
+        comodel_name="affiliate.class.basic",
+        string="Clase",
+        required=True,
+        ondelete="cascade",
+        default=_default_class_basic_id,
+    )
+
+    class_number = fields.Integer(
+        string="N° Clase",
+        related="class_basic_id.class_number",
+        store=True,
+    )
+
+    date_month = fields.Selection(
+        selection=[
+            ('01', 'Enero'), ('02', 'Febrero'), ('03', 'Marzo'),
+            ('04', 'Abril'), ('05', 'Mayo'), ('06', 'Junio'),
+            ('07', 'Julio'), ('08', 'Agosto'), ('09', 'Septiembre'),
+            ('10', 'Octubre'), ('11', 'Noviembre'), ('12', 'Diciembre'),
+        ],
+        string="Mes",
+        required=True,
+    )
+
+    @api.model
+    def _get_year_selection(self):
+        current_year = datetime.now().year
+        return [(str(year), str(year)) for year in
+                reversed(range(current_year - 10, current_year + 11))]
+
+    date_year = fields.Selection(
+        selection=_get_year_selection,
+        string="Año",
+        required=True,
+    )
+
+    basic_amount = fields.Float(
+        string="Básico",
+        digits='Product Price',
+        required=True,
+    )
+
+    manually_modified = fields.Boolean(
+        string="Modificado manualmente",
+        default=False,
+    )
+
+    _sql_constraints = [
+        ('unique_class_month_year',
+         'unique(class_basic_id, date_month, date_year)',
+         'Ya existe un registro de historial para esta clase, mes y año.')
+    ]
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        """
+        Override create: cuando se crea un registro de clase 1 desde la vista,
+        marca manually_modified=True y propaga a todas las clases.
+        """
+        records = super().create(vals_list)
+
+        if not self.env.context.get('_skip_history_propagation'):
+            for record in records:
+                if record.class_number == 1:
+                    self.set_class1_basic_for_month(
+                        record.date_month, record.date_year, record.basic_amount)
+
+        return records
+
+    def name_get(self):
+        month_names = {
+            '01': 'Enero', '02': 'Febrero', '03': 'Marzo', '04': 'Abril',
+            '05': 'Mayo', '06': 'Junio', '07': 'Julio', '08': 'Agosto',
+            '09': 'Septiembre', '10': 'Octubre', '11': 'Noviembre', '12': 'Diciembre',
+        }
+        result = []
+        for record in self:
+            month = month_names.get(record.date_month, record.date_month)
+            name = f"Clase {record.class_number} - {month} {record.date_year} - ${record.basic_amount:,.2f}"
+            result.append((record.id, name))
+        return result
+
+    @api.model
+    def get_basic_for_month(self, class_number, month, year):
+        """
+        Obtiene el básico de una clase para un mes/año dado.
+        Busca registro exacto -> si no existe, camina hacia atrás -> fallback al básico actual.
+        """
+        month = str(month).zfill(2)
+        year = str(year)
+
+        # Buscar registro exacto
+        record = self.search([
+            ('class_number', '=', class_number),
+            ('date_month', '=', month),
+            ('date_year', '=', year),
+        ], limit=1)
+        if record:
+            return record.basic_amount
+
+        # Caminar hacia atrás: buscar el registro más reciente anterior
+        all_records = self.search([
+            ('class_number', '=', class_number),
+        ], order='date_year desc, date_month desc')
+
+        target_date = int(year) * 100 + int(month)
+        for rec in all_records:
+            rec_date = int(rec.date_year) * 100 + int(rec.date_month)
+            if rec_date < target_date:
+                return rec.basic_amount
+
+        # Fallback: básico actual del modelo affiliate.class.basic
+        class_basic = self.env['affiliate.class.basic'].search([
+            ('class_number', '=', class_number),
+            ('active', '=', True),
+        ], limit=1)
+        return class_basic.basic_amount if class_basic else 0.0
+
+    @api.model
+    def set_class1_basic_for_month(self, month, year, amount):
+        """
+        Punto de entrada para ediciones del básico de clase 1.
+        - Upsert clase 1 con manually_modified=True
+        - Upsert clases 2-20 con amount * class_index, manually_modified=False
+        - Propagar mes a mes hacia adelante hasta encontrar otro manually_modified=True en clase 1
+        - Recalcular union_fee en payment_accounts de meses afectados
+        """
+        month = str(month).zfill(2)
+        year = str(year)
+
+        ClassBasic = self.env['affiliate.class.basic']
+        all_classes = ClassBasic.search([], order='class_number asc')
+
+        # Upsert para el mes dado
+        affected_months = []
+        self._upsert_all_classes(month, year, amount, all_classes, manually_modified_class1=True)
+        affected_months.append((month, year))
+
+        # Propagar hacia adelante
+        next_month, next_year = self._next_month(month, year)
+        while True:
+            # Verificar si existe un registro de clase 1 marcado como manually_modified
+            class1_basic = ClassBasic.search([('class_number', '=', 1)], limit=1)
+            if not class1_basic:
+                break
+
+            next_record = self.search([
+                ('class_basic_id', '=', class1_basic.id),
+                ('date_month', '=', next_month),
+                ('date_year', '=', next_year),
+            ], limit=1)
+
+            if next_record and next_record.manually_modified:
+                # Encontramos un mes con modificación manual, detenemos propagación
+                break
+
+            if not next_record:
+                # No hay más registros hacia adelante, detenemos
+                break
+
+            # Propagar: actualizar este mes con el mismo amount de clase 1
+            self._upsert_all_classes(next_month, next_year, amount, all_classes, manually_modified_class1=False)
+            affected_months.append((next_month, next_year))
+
+            next_month, next_year = self._next_month(next_month, next_year)
+
+        # Recalcular union_fee en payment_accounts de meses afectados
+        self._recompute_union_fees_for_months(affected_months)
+
+        # Actualizar affiliate.class.basic si el registro más reciente cambió
+        latest_class1 = self.search([
+            ('class_number', '=', 1),
+        ], order='date_year desc, date_month desc', limit=1)
+
+        if latest_class1:
+            class1_basic = ClassBasic.search([('class_number', '=', 1)], limit=1)
+            if class1_basic and class1_basic.basic_amount != latest_class1.basic_amount:
+                class1_basic.with_context(
+                    _skip_history_creation=True
+                ).write({
+                    'basic_amount': latest_class1.basic_amount,
+                    'basic_amount_class1': latest_class1.basic_amount,
+                })
+
+    @api.model
+    def _upsert_all_classes(self, month, year, class1_amount, all_classes, manually_modified_class1=False):
+        """Crea o actualiza registros de historial para todas las clases en un mes/año."""
+        for class_basic in all_classes:
+            if class_basic.class_number == 1:
+                amount = class1_amount
+                manually = manually_modified_class1
+            else:
+                amount = class1_amount * class_basic.class_index
+                manually = False
+
+            existing = self.search([
+                ('class_basic_id', '=', class_basic.id),
+                ('date_month', '=', month),
+                ('date_year', '=', year),
+            ], limit=1)
+
+            if existing:
+                vals = {'basic_amount': amount}
+                if class_basic.class_number == 1:
+                    vals['manually_modified'] = manually
+                # Bypass write override to avoid recursion
+                super(AffiliateClassBasicHistory, existing).write(vals)
+            else:
+                self.with_context(_skip_history_propagation=True).create({
+                    'class_basic_id': class_basic.id,
+                    'date_month': month,
+                    'date_year': year,
+                    'basic_amount': amount,
+                    'manually_modified': manually,
+                })
+
+    @api.model
+    def _next_month(self, month, year):
+        """Retorna el mes y año siguiente."""
+        m = int(month)
+        y = int(year)
+        if m == 12:
+            return '01', str(y + 1)
+        return str(m + 1).zfill(2), str(y)
+
+    @api.model
+    def _recompute_union_fees_for_months(self, months):
+        """Recalcula union_fee para todos los payment_account de los meses dados."""
+        PaymentAccount = self.env['affiliate.payment_account']
+        for month, year in months:
+            records = PaymentAccount.search([
+                ('date_month', '=', month),
+                ('date_year', '=', year),
+            ])
+            for record in records:
+                record._compute_union_fee()
+                record._compute_total()
+                record._compute_final_balance()
+                record._update_subsequent_months_initial_balance()
+
+    @api.model
+    def ensure_month_exists(self, month, year):
+        """
+        Asegura que existan registros de historial para todas las clases en un mes/año.
+        Si no existen, los crea heredando del mes anterior.
+        """
+        month = str(month).zfill(2)
+        year = str(year)
+
+        ClassBasic = self.env['affiliate.class.basic']
+        all_classes = ClassBasic.search([], order='class_number asc')
+
+        for class_basic in all_classes:
+            existing = self.search([
+                ('class_basic_id', '=', class_basic.id),
+                ('date_month', '=', month),
+                ('date_year', '=', year),
+            ], limit=1)
+
+            if not existing:
+                # Heredar del mes anterior
+                amount = self.get_basic_for_month(class_basic.class_number, month, year)
+                self.with_context(_skip_history_propagation=True).create({
+                    'class_basic_id': class_basic.id,
+                    'date_month': month,
+                    'date_year': year,
+                    'basic_amount': amount,
+                    'manually_modified': False,
+                })
+
+    def unlink(self):
+        """
+        Override unlink: al borrar registros de historial de clase 1,
+        también borra los registros de las demás clases del mismo mes/año.
+        Actualiza affiliate.class.basic con el valor del registro más reciente restante.
+        Recalcula union_fee para los meses afectados.
+        """
+        if self.env.context.get('_skip_cascade_delete'):
+            return super().unlink()
+
+        # Capturar meses afectados y meses con clase 1
+        affected_months = set()
+        class1_months = set()
+        for record in self:
+            affected_months.add((record.date_month, record.date_year))
+            if record.class_number == 1:
+                class1_months.add((record.date_month, record.date_year))
+
+        result = super().unlink()
+
+        if class1_months:
+            # Borrar registros de otras clases para los mismos meses
+            for month, year in class1_months:
+                other_records = self.search([
+                    ('date_month', '=', month),
+                    ('date_year', '=', year),
+                ])
+                if other_records:
+                    other_records.with_context(_skip_cascade_delete=True).unlink()
+
+            # Actualizar affiliate.class.basic desde el registro más reciente restante
+            ClassBasic = self.env['affiliate.class.basic']
+            class1_basic = ClassBasic.search([('class_number', '=', 1)], limit=1)
+
+            if class1_basic:
+                latest_class1 = self.search([
+                    ('class_number', '=', 1),
+                ], order='date_year desc, date_month desc', limit=1)
+
+                if latest_class1:
+                    # Propagar el valor del registro más reciente restante
+                    # Usar _skip_history_creation para no re-crear registros
+                    class1_basic.with_context(
+                        _skip_history_creation=True
+                    ).write({
+                        'basic_amount': latest_class1.basic_amount,
+                        'basic_amount_class1': latest_class1.basic_amount,
+                    })
+
+        # Recalcular union_fee de meses afectados
+        if affected_months:
+            self._recompute_union_fees_for_months(list(affected_months))
+
+        return result
+
+    def write(self, vals):
+        """
+        Override write: cuando se edita basic_amount de clase 1 desde la vista,
+        marca manually_modified=True y propaga via set_class1_basic_for_month.
+        """
+        # Detectar si se edita basic_amount en un registro de clase 1
+        if 'basic_amount' in vals:
+            for record in self:
+                if record.class_number == 1:
+                    # Llamar set_class1_basic_for_month que maneja todo
+                    self.env['affiliate.class.basic.history'].set_class1_basic_for_month(
+                        record.date_month, record.date_year, vals['basic_amount']
+                    )
+                    return True
+
+        return super().write(vals)

--- a/road_union_economic_management/models/payment_account.py
+++ b/road_union_economic_management/models/payment_account.py
@@ -262,43 +262,28 @@ class AffiliatePaymentAccount(models.Model):
         Calcula la cuota sindical según las reglas:
         - Activos: 1.5% del básico de su clase + 1.5% del básico de clase 15
         - Jubilados: 75% de lo que pagaría un activo (0.75 * cuota activo)
+        Usa el historial mensual de básicos para obtener el valor correcto del mes.
         """
+        History = self.env['affiliate.class.basic.history']
         for record in self:
             if not record.affiliate_id or not record.affiliate_id.category:
                 record.union_fee = 0.0
                 continue
-                
+
             affiliate_class = record.affiliate_id.category
             affiliate_type = record.affiliate_id.affiliate_type_id.name if record.affiliate_id.affiliate_type_id else ''
-            
-            class_basic = self.env['affiliate.class.basic'].search([
-                ('class_number', '=', affiliate_class),
-                ('active', '=', True)
-            ], limit=1)
-            
-            if not class_basic:
-                record.union_fee = 0.0
-                continue
-                
-            is_retired = any(keyword in affiliate_type.lower() for keyword in ['jubilado', 'pensionado', 'retirado'])
-            
-            # Calcular cuota como activo
-            own_class_fee = class_basic.basic_amount * 0.015
-            
-            class_15_basic = self.env['affiliate.class.basic'].search([
-                ('class_number', '=', 15),
-                ('active', '=', True)
-            ], limit=1)
-            
-            if class_15_basic:
-                class_15_fee = class_15_basic.basic_amount * 0.015
-                record.union_fee = own_class_fee + class_15_fee
-            else:
-                record.union_fee = own_class_fee
-            
-            # Si es jubilado, aplicar el 75%
+
+            own_basic = History.get_basic_for_month(
+                affiliate_class, record.date_month, record.date_year)
+            class_15_basic = History.get_basic_for_month(
+                15, record.date_month, record.date_year)
+
+            is_retired = any(keyword in affiliate_type.lower()
+                            for keyword in ['jubilado', 'pensionado', 'retirado'])
+
+            record.union_fee = own_basic * 0.015 + class_15_basic * 0.015
             if is_retired:
-                record.union_fee = record.union_fee * 0.75
+                record.union_fee *= 0.75
 
     total_services = fields.Float(
         string="TOTAL SERVICIOS",
@@ -396,6 +381,10 @@ class AffiliatePaymentAccount(models.Model):
     def create(self, vals):
         """Override create para recalcular saldos posteriores y aplicar planes de cuotas"""
         record = super(AffiliatePaymentAccount, self).create(vals)
+        # Asegurar que existan registros de historial para este mes
+        if record.date_month and record.date_year:
+            self.env['affiliate.class.basic.history'].ensure_month_exists(
+                record.date_month, record.date_year)
         record._update_subsequent_months_initial_balance()
         # Aplicar planes de cuotas activos del afiliado
         active_plans = self.env['affiliate.installment.plan'].search([
@@ -511,6 +500,9 @@ class AffiliatePaymentAccount(models.Model):
                 errors.append(f"Error con afiliado {affiliate.name}: {str(e)}")
                 _logger.error(f"Error creating payment account for {affiliate.name}: {e}")
         
+        # Asegurar que existan registros de historial de básicos para este mes
+        self.env['affiliate.class.basic.history'].ensure_month_exists(month, year)
+
         result = {
             'created': created_count,
             'skipped': skipped_count,
@@ -519,7 +511,7 @@ class AffiliatePaymentAccount(models.Model):
             'month': month,
             'year': year,
         }
-        
+
         _logger.info(f"Monthly records creation: {result}")
         return result
 
@@ -651,11 +643,11 @@ class AffiliateClassBasic(models.Model):
         """
         Override write para:
         1. Actualizar basic_amount_class1 si se modifica basic_amount en clase 1
-        2. Recalcular union_fee cuando se modifica el básico
+        2. Recalcular union_fee cuando se modifica el básico (via historial)
         3. Propagar cambios a todas las clases cuando se modifica clase 1
         """
         result = super(AffiliateClassBasic, self).write(vals)
-        
+
         # Si se modificó basic_amount en la clase 1, actualizar todas las demás clases
         if 'basic_amount' in vals:
             for record in self:
@@ -665,20 +657,30 @@ class AffiliateClassBasic(models.Model):
                         super(AffiliateClassBasic, record).write({
                             'basic_amount_class1': vals['basic_amount']
                         })
-                    
+
                     # Recalcular todas las demás clases
                     other_classes = self.search([('class_number', '!=', 1)])
                     other_classes._compute_basic_amount()
-            
-            # Actualizar las cuotas sindicales
-            self._update_union_fees_from_current_month()
-        
+
+                    # Crear historial del mes actual y recalcular cuotas
+                    if not self.env.context.get('_skip_history_creation'):
+                        today = datetime.now()
+                        History = self.env['affiliate.class.basic.history']
+                        History.set_class1_basic_for_month(
+                            today.strftime('%m'), str(today.year), vals['basic_amount'])
+
         # Si se modificó basic_amount_class1, recalcular todas las clases
         if 'basic_amount_class1' in vals:
             all_classes = self.search([])
             all_classes._compute_basic_amount()
-            self._update_union_fees_from_current_month()
-        
+            if not self.env.context.get('_skip_history_creation'):
+                today = datetime.now()
+                class1 = self.search([('class_number', '=', 1)], limit=1)
+                if class1:
+                    History = self.env['affiliate.class.basic.history']
+                    History.set_class1_basic_for_month(
+                        today.strftime('%m'), str(today.year), class1.basic_amount)
+
         return result
     
     @api.model_create_multi
@@ -705,8 +707,11 @@ class AffiliateClassBasic(models.Model):
             # Recalcular todas las clases
             all_classes = self.search([])
             all_classes._compute_basic_amount()
-            # Actualizar cuotas sindicales
-            self._update_union_fees_from_current_month()
+            # Crear historial del mes actual y recalcular cuotas
+            today = datetime.now()
+            History = self.env['affiliate.class.basic.history']
+            History.set_class1_basic_for_month(
+                today.strftime('%m'), str(today.year), self.basic_amount)
             return {
                 'type': 'ir.actions.client',
                 'tag': 'display_notification',
@@ -717,43 +722,3 @@ class AffiliateClassBasic(models.Model):
                     'sticky': False,
                 }
             }
-    
-    def _update_union_fees_from_current_month(self):
-        """
-        Recalcula union_fee para todos los payment_account del mes actual
-        y meses futuros que usen esta clase o clase 15.
-        """
-        for class_basic in self:
-            today = datetime.now()
-            current_month = today.strftime('%m')
-            current_year = str(today.year)
-            
-            PaymentAccount = self.env['affiliate.payment_account']
-            
-            affected_affiliates = self.env['affiliation.affiliate'].search([
-                ('category', '=', class_basic.class_number)
-            ])
-            
-            if class_basic.class_number == 15:
-                all_affiliates = self.env['affiliation.affiliate'].search([])
-                active_affiliates = all_affiliates.filtered(
-                    lambda a: a.affiliate_type_id and 
-                    not any(keyword in a.affiliate_type_id.name.lower() 
-                            for keyword in ['jubilado', 'pensionado', 'retirado'])
-                )
-                affected_affiliates |= active_affiliates
-            
-            all_records = PaymentAccount.search([
-                ('affiliate_id', 'in', affected_affiliates.ids),
-            ])
-            
-            current_date = datetime(int(current_year), int(current_month), 1)
-            records_to_update = all_records.filtered(
-                lambda r: datetime(int(r.date_year), int(r.date_month), 1) >= current_date
-            )
-            
-            for record in records_to_update:
-                record._compute_union_fee()
-                record._compute_total()
-                record._compute_final_balance()
-                record._update_subsequent_months_initial_balance()

--- a/road_union_economic_management/security/ir.model.access.csv
+++ b/road_union_economic_management/security/ir.model.access.csv
@@ -41,3 +41,6 @@ access_affiliate_installment_plan_read,Read access to Installment Plan,model_aff
 access_installment_plan_wizard_admin,Admin access to Installment Plan Wizard,model_installment_plan_wizard,union_affiliation.group_affiliation_admin,1,1,1,1
 access_installment_plan_wizard_write,Write access to Installment Plan Wizard,model_installment_plan_wizard,union_affiliation.group_affiliation_write,1,1,1,1
 access_installment_plan_wizard_read,Read access to Installment Plan Wizard,model_installment_plan_wizard,union_affiliation.group_affiliation_read,1,1,1,1
+access_affiliate_class_basic_history_admin,Admin access to Class Basic History,model_affiliate_class_basic_history,union_affiliation.group_affiliation_admin,1,1,1,1
+access_affiliate_class_basic_history_write,Write access to Class Basic History,model_affiliate_class_basic_history,union_affiliation.group_affiliation_write,1,1,1,0
+access_affiliate_class_basic_history_read,Read access to Class Basic History,model_affiliate_class_basic_history,union_affiliation.group_affiliation_read,1,0,0,0

--- a/road_union_economic_management/views/affiliate_class_basic_history_views.xml
+++ b/road_union_economic_management/views/affiliate_class_basic_history_views.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Vista de lista editable (filtrada a clase 1) -->
+    <record id="view_affiliate_class_basic_history_tree" model="ir.ui.view">
+        <field name="name">affiliate.class.basic.history.tree</field>
+        <field name="model">affiliate.class.basic.history</field>
+        <field name="arch" type="xml">
+            <tree string="Historial de Básicos" editable="bottom"
+                  decoration-info="manually_modified == True">
+                <field name="class_basic_id" invisible="1"/>
+                <field name="class_number" readonly="1"/>
+                <field name="date_month"/>
+                <field name="date_year"/>
+                <field name="basic_amount" widget="monetary"/>
+                <field name="manually_modified" widget="boolean"
+                       readonly="1"/>
+            </tree>
+        </field>
+    </record>
+
+    <!-- Vista de búsqueda -->
+    <record id="view_affiliate_class_basic_history_search" model="ir.ui.view">
+        <field name="name">affiliate.class.basic.history.search</field>
+        <field name="model">affiliate.class.basic.history</field>
+        <field name="arch" type="xml">
+            <search string="Buscar Historial de Básicos">
+                <field name="class_number"/>
+                <field name="date_month"/>
+                <field name="date_year"/>
+                <filter string="Clase 1" name="class_1"
+                        domain="[('class_number', '=', 1)]"/>
+                <filter string="Modificado manualmente" name="manually_modified"
+                        domain="[('manually_modified', '=', True)]"/>
+                <separator/>
+                <group expand="0" string="Agrupar por">
+                    <filter string="Año" name="group_year"
+                            context="{'group_by': 'date_year'}"/>
+                    <filter string="Mes" name="group_month"
+                            context="{'group_by': 'date_month'}"/>
+                    <filter string="Clase" name="group_class"
+                            context="{'group_by': 'class_number'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <!-- Acción de ventana (filtro clase 1 por defecto, removible) -->
+    <record id="action_affiliate_class_basic_history" model="ir.actions.act_window">
+        <field name="name">Historial de Básicos</field>
+        <field name="res_model">affiliate.class.basic.history</field>
+        <field name="view_mode">tree</field>
+        <field name="domain" eval="[]"/>
+        <field name="context">{'search_default_class_1': 1}</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                No hay registros de historial de básicos
+            </p>
+            <p>
+                El historial se crea automáticamente al generar registros mensuales
+                o al modificar el básico de clase 1.
+            </p>
+            <p>
+                <strong>Nota:</strong> Solo se puede editar el básico de la Clase 1.
+                Al modificar un mes, los cambios se propagan automáticamente hacia adelante
+                hasta el próximo mes marcado como "modificado manualmente".
+            </p>
+        </field>
+    </record>
+
+    <!-- Menú -->
+    <menuitem id="menu_affiliate_class_basic_history"
+              name="Historial de Básicos"
+              parent="union_affiliation.affiliates_section"
+              action="action_affiliate_class_basic_history"
+              sequence="11"/>
+</odoo>


### PR DESCRIPTION
## Summary
- New model `affiliate.class.basic.history` that tracks basic amounts per class per month/year
- Editing a class 1 basic from the history view marks it as `manually_modified` and propagates forward to subsequent months until the next manually modified month is found
- `_compute_union_fee` in payment accounts now uses historical basic amounts via `get_basic_for_month()` instead of current class basic values
- `post_init_hook` creates history records for all existing payment account months on first install
- `ensure_month_exists` is called on both individual and bulk payment account creation
- Cascade delete: deleting a class 1 history record also deletes all other classes for that month
- Editable tree view with class 1 filter active by default (removable to see all classes)

## Test plan
- [x] Install module on fresh database with existing payment accounts, verify history records are created for all months
- [x] Edit class 1 basic from "Basicos por Clase" view, verify current month history is created
- [x] Edit a past month's basic from history view, verify forward propagation stops at next manually_modified month
- [x] Create a new history record from the view, verify `manually_modified=True` and propagation works
- [x] Delete a history record, verify cascade delete of other classes and `affiliate.class.basic` updates from latest remaining
- [x] Verify `union_fee` in payment accounts uses historical basic amounts
- [x] Remove "Clase 1" filter in history view, verify all classes are visible

Closes #71