### PR TITLE
Update affiliate tree view for re-import compatibility

### DIFF
--- a/road_union_affiliation/views/affiliate_old_db_views.xml
+++ b/road_union_affiliation/views/affiliate_old_db_views.xml
@@ -45,6 +45,11 @@
       <field name="model">affiliation.affiliate</field>
       <field name="arch" type="xml">
           <search>
+              <field name="display_full_name" string="Apellido y Nombre"/>
+              <field name="last_name"/>
+              <field name="first_name"/>
+              <field name="uid" string="Legajo"/>
+              <field name="personal_id" string="DNI"/>
               <field name="affiliate_type_id"/>
 
               <filter string="Activos"

--- a/road_union_affiliation/views/affiliate_old_db_views.xml
+++ b/road_union_affiliation/views/affiliate_old_db_views.xml
@@ -4,7 +4,13 @@
         <field name="model">affiliation.affiliate</field>
         <field name="arch" type="xml">
             <tree class="o_sticky_list">
-                <field name="name" string="Apellido y Nombre"/>
+                <!-- WORKAROUND: usamos display_full_name en vez de name porque
+                     el quick export usa el `string` del field del modelo, y
+                     `name` y `first_name` ambos tienen string="Nombre",
+                     duplicando el header. Ver comentario en el modelo. -->
+                <field name="display_full_name"/>
+                <field name="last_name" optional="hide"/>
+                <field name="first_name" optional="hide"/>
                 <field name="gender"/>
                 <field name="department_id"/>
                 <field name="affiliate_type_id"/>

--- a/road_union_economic_management/views/affiliate_views.xml
+++ b/road_union_economic_management/views/affiliate_views.xml
@@ -5,7 +5,7 @@
       <field name="model">affiliation.affiliate</field>
       <field name="inherit_id" ref="road_union_affiliation.odoo_road_union_affiliate_form_inherit"/>
       <field name="arch" type="xml">
-        
+
         <xpath expr="//group[@name='personal_information']/field[@name='seniority']" position="after">
           <field name="id_benefit"/>
         </xpath>
@@ -16,6 +16,19 @@
           </page>
         </xpath>
 
+      </field>
+    </record>
+
+    <!-- Agregar id_benefit al tree view de afiliados (definido en road_union_affiliation
+         pero el campo se define acá, por eso necesitamos este inherit) -->
+    <record id="view_affiliate_tree_inherit_id_benefit" model="ir.ui.view">
+      <field name="name">affiliation.affiliate.tree.inherit.id_benefit</field>
+      <field name="model">affiliation.affiliate</field>
+      <field name="inherit_id" ref="road_union_affiliation.view_affiliate_tree"/>
+      <field name="arch" type="xml">
+        <xpath expr="//field[@name='first_name']" position="after">
+          <field name="id_benefit"/>
+        </xpath>
       </field>
     </record>
   </data>


### PR DESCRIPTION
## Summary
- Replace `name` with `display_full_name` (introduced in MarvinSoftwareSolutions/odoo-union#28) — same display, but the export header no longer collides with `first_name`'s "Nombre"
- Add `last_name` and `first_name` as `optional="hide"` columns — UI unchanged by default, available for export when needed
- Add `id_benefit` as visible column via inherit from road_union_economic_management (field belongs to that module)
- Extend the search view of "Affiliate Database View": add `display_full_name`, `last_name`, `first_name`, `uid` (Legajo) and `personal_id` (DNI) as search fields. Previously only `affiliate_type_id` was searchable, so typing in the search bar tried to match types of employment relationship instead of affiliates.

## Depends on
- MarvinSoftwareSolutions/odoo-union#28 (must be merged first for `display_full_name` to exist)

## Test plan
- [x] Open Afiliados list — should show "Apellido y Nombre", id_benefit (visible) and other columns; last_name/first_name hidden by default
- [x] Toggle the optional columns — last_name and first_name should appear
- [x] Quick export — XLSX headers should be "Apellido y Nombre", "Apellido", "Nombre" (no duplicates), and include "ID/BENEFIT"
- [x] Re-import the exported XLSX — should work without manual edits
- [x] In the affiliate list search bar, type a name/last_name/uid/dni — should filter affiliates correctly

Closes #78