### PR TITLE
Padrones temáticos, eventos con asistencia digital y vista de bajas

### DIFF
--- a/road_union_affiliation/__manifest__.py
+++ b/road_union_affiliation/__manifest__.py
@@ -21,6 +21,7 @@
         'views/department_views.xml',
         'views/affiliate_old_db_views.xml',
         'views/affiliate_child_readonly_views.xml',
+        'views/padrones_views.xml',
         'data/insurance_data.xml',
         'security/ir.model.access.csv',
     ],

--- a/road_union_affiliation/__manifest__.py
+++ b/road_union_affiliation/__manifest__.py
@@ -22,6 +22,7 @@
         'views/affiliate_old_db_views.xml',
         'views/affiliate_child_readonly_views.xml',
         'views/padrones_views.xml',
+        'views/event_views.xml',
         'data/insurance_data.xml',
         'security/ir.model.access.csv',
     ],

--- a/road_union_affiliation/models/__init__.py
+++ b/road_union_affiliation/models/__init__.py
@@ -1,1 +1,1 @@
-from . import affiliate, insurance, department, affiliate_child
+from . import affiliate, insurance, department, affiliate_child, event

--- a/road_union_affiliation/models/event.py
+++ b/road_union_affiliation/models/event.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+from odoo import models, fields, api
+
+
+class AffiliationEvent(models.Model):
+    _name = 'affiliation.event'
+    _description = 'Evento del sindicato con registro de asistencia'
+    _order = 'date desc'
+
+    name = fields.Char(string='Nombre', required=True)
+    event_type = fields.Selection([
+        ('asamblea', 'Asamblea'),
+        ('fiesta', 'Fiesta'),
+        ('eleccion', 'Elección'),
+        ('otro', 'Otro'),
+    ], string='Tipo', required=True, default='asamblea')
+    date = fields.Date(string='Fecha', required=True,
+                       default=fields.Date.context_today)
+    description = fields.Text(string='Descripción')
+
+    # La búsqueda para agregar asistentes acepta nombre, legajo (uid) o DNI
+    # gracias al _name_search del afiliado.
+    attendee_ids = fields.Many2many(
+        'affiliation.affiliate',
+        'affiliation_event_attendee_rel',
+        'event_id', 'affiliate_id',
+        string='Asistentes')
+
+    attendee_count = fields.Integer(
+        string='Cantidad de asistentes',
+        compute='_compute_attendee_count', store=True)
+
+    @api.depends('attendee_ids')
+    def _compute_attendee_count(self):
+        for event in self:
+            event.attendee_count = len(event.attendee_ids)

--- a/road_union_affiliation/security/ir.model.access.csv
+++ b/road_union_affiliation/security/ir.model.access.csv
@@ -6,3 +6,6 @@ read_affiliation_insurance,Read access to insurance,model_affiliation_insurance,
 admin_affiliation_department,Admin access to department,model_affiliation_department,union_affiliation.group_affiliation_admin,1,1,1,1
 write_affiliation_department,Write access to department,model_affiliation_department,union_affiliation.group_affiliation_write,1,1,1,0
 read_affiliation_department,Read access to department,model_affiliation_department,union_affiliation.group_affiliation_read,1,0,0,0
+admin_affiliation_event,Admin access to Affiliation Event,model_affiliation_event,union_affiliation.group_affiliation_admin,1,1,1,1
+write_affiliation_event,Write access to Affiliation Event,model_affiliation_event,union_affiliation.group_affiliation_write,1,1,1,0
+read_affiliation_event,Read access to Affiliation Event,model_affiliation_event,union_affiliation.group_affiliation_read,1,0,0,0

--- a/road_union_affiliation/views/affiliate_old_db_views.xml
+++ b/road_union_affiliation/views/affiliate_old_db_views.xml
@@ -31,6 +31,10 @@
                 <field name="mobile"/>
                 <field name="affiliation_date"/>
                 <field name="seniority"/>
+                <!-- Visibles al consultar históricos/bajas -->
+                <field name="state" optional="hide"/>
+                <field name="disaffiliation_date" optional="hide"/>
+                <field name="current_disaffiliation_reason" optional="hide" string="Motivo de baja"/>
                 <field name="affiliate_child_ids" invisible="1"/>
                 <button name="action_view_children"
                         type="object"

--- a/road_union_affiliation/views/event_views.xml
+++ b/road_union_affiliation/views/event_views.xml
@@ -1,0 +1,86 @@
+<odoo>
+    <record id="view_affiliation_event_tree" model="ir.ui.view">
+        <field name="name">affiliation.event.tree</field>
+        <field name="model">affiliation.event</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="date"/>
+                <field name="name"/>
+                <field name="event_type"/>
+                <field name="attendee_count"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_affiliation_event_form" model="ir.ui.view">
+        <field name="name">affiliation.event.form</field>
+        <field name="model">affiliation.event</field>
+        <field name="arch" type="xml">
+            <form string="Evento">
+                <sheet>
+                    <div class="oe_title">
+                        <h1><field name="name" placeholder="Ej: Asamblea General Marzo"/></h1>
+                    </div>
+                    <group>
+                        <group>
+                            <field name="event_type"/>
+                            <field name="date"/>
+                        </group>
+                        <group>
+                            <field name="attendee_count"/>
+                        </group>
+                    </group>
+                    <field name="description" placeholder="Observaciones del evento..."/>
+                    <notebook>
+                        <page string="Asistentes">
+                            <!-- Se puede buscar por apellido, legajo o DNI -->
+                            <field name="attendee_ids">
+                                <tree>
+                                    <field name="display_full_name"/>
+                                    <field name="uid" string="Legajo"/>
+                                    <field name="personal_id" string="DNI"/>
+                                    <field name="department_id"/>
+                                    <field name="affiliate_type_id"/>
+                                </tree>
+                            </field>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="view_affiliation_event_search" model="ir.ui.view">
+        <field name="name">affiliation.event.search</field>
+        <field name="model">affiliation.event</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="name"/>
+                <filter string="Asambleas" name="asambleas"
+                        domain="[('event_type', '=', 'asamblea')]"/>
+                <filter string="Fiestas" name="fiestas"
+                        domain="[('event_type', '=', 'fiesta')]"/>
+                <filter string="Elecciones" name="elecciones"
+                        domain="[('event_type', '=', 'eleccion')]"/>
+                <group expand="0" string="Agrupar por">
+                    <filter string="Tipo" name="groupby_tipo"
+                            context="{'group_by': 'event_type'}"/>
+                    <filter string="Fecha" name="groupby_fecha"
+                            context="{'group_by': 'date'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <record id="action_affiliation_event" model="ir.actions.act_window">
+        <field name="name">Eventos y Asistencia</field>
+        <field name="res_model">affiliation.event</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <menuitem id="menu_affiliation_event" name="Eventos y Asistencia"
+              parent="union_affiliation.union"
+              action="action_affiliation_event"
+              groups="union_affiliation.group_affiliation_read"
+              sequence="16"/>
+</odoo>

--- a/road_union_affiliation/views/padrones_views.xml
+++ b/road_union_affiliation/views/padrones_views.xml
@@ -22,6 +22,10 @@
                 <filter string="Afiliados vigentes"
                         name="vigentes"
                         domain="[('state', '=', 'affiliated')]"/>
+                <filter string="Dados de baja"
+                        name="dados_de_baja"
+                        domain="[('state', 'in', ['disaffiliated', 'historical'])]"
+                        help="Bajas por renuncia o fallecimiento: ver columnas Fecha de baja y Motivo"/>
                 <group expand="0" string="Agrupar por">
                     <filter string="Departamento"
                             name="groupby_departamento"

--- a/road_union_affiliation/views/padrones_views.xml
+++ b/road_union_affiliation/views/padrones_views.xml
@@ -1,0 +1,163 @@
+<odoo>
+    <!-- ==================== FILTROS Y AGRUPACIONES PARA PADRONES ==================== -->
+
+    <!-- Extiende la búsqueda de la vista de base de datos de afiliados -->
+    <record id="affiliate_padrones_search" model="ir.ui.view">
+        <field name="name">affiliation.affiliate.padrones.search</field>
+        <field name="model">affiliation.affiliate</field>
+        <field name="inherit_id" ref="affiliate_active_search"/>
+        <field name="arch" type="xml">
+            <filter name="activos" position="after">
+                <filter string="Jubilados"
+                        name="jubilados"
+                        domain="[('affiliate_type_id.name', '=', 'Jubilado')]"/>
+                <separator/>
+                <filter string="Padres"
+                        name="padres"
+                        domain="[('parent_role', '=', 'father')]"/>
+                <filter string="Madres"
+                        name="madres"
+                        domain="[('parent_role', '=', 'mother')]"/>
+                <separator/>
+                <filter string="Afiliados vigentes"
+                        name="vigentes"
+                        domain="[('state', '=', 'affiliated')]"/>
+                <group expand="0" string="Agrupar por">
+                    <filter string="Departamento"
+                            name="groupby_departamento"
+                            context="{'group_by': 'department_id'}"/>
+                    <filter string="Clase"
+                            name="groupby_clase"
+                            context="{'group_by': 'category'}"/>
+                    <filter string="Tipo de afiliado"
+                            name="groupby_tipo"
+                            context="{'group_by': 'affiliate_type_id'}"/>
+                    <filter string="Rol parental"
+                            name="groupby_rol"
+                            context="{'group_by': 'parent_role'}"/>
+                </group>
+            </filter>
+        </field>
+    </record>
+
+    <!-- Búsqueda de hijos: hasta ahora los listados de hijos no tenían search view propia -->
+    <record id="affiliate_child_padrones_search" model="ir.ui.view">
+        <field name="name">affiliation.affiliate_child.padrones.search</field>
+        <field name="model">affiliation.affiliate_child</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="name"/>
+                <field name="personal_id" string="DNI"/>
+                <field name="affiliate_uids" string="Legajo del padre/madre"/>
+                <field name="affiliate_department_1" string="Departamento"/>
+
+                <!-- Edad calculada por fecha de nacimiento para no depender del
+                     computed store (que puede quedar desactualizado con el tiempo) -->
+                <filter string="Menores de 13"
+                        name="menores_13"
+                        domain="[('birth_date', '&gt;', (context_today() - relativedelta(years=13)).strftime('%Y-%m-%d'))]"/>
+                <separator/>
+                <filter string="Jardín"
+                        name="nivel_jardin"
+                        domain="[('educational_level', '=', 'jardin')]"/>
+                <filter string="Primaria 1° a 3°"
+                        name="nivel_primaria_1_3"
+                        domain="[('educational_level', '=', 'primaria_1_3')]"/>
+                <filter string="Primaria 4° a 6°"
+                        name="nivel_primaria_4_6"
+                        domain="[('educational_level', '=', 'primaria_4_6')]"/>
+                <filter string="Secundaria"
+                        name="nivel_secundaria"
+                        domain="[('educational_level', '=', 'secundaria')]"/>
+                <filter string="En edad escolar"
+                        name="en_edad_escolar"
+                        domain="[('educational_level', 'in', ['jardin', 'primaria_1_3', 'primaria_4_6', 'secundaria'])]"/>
+                <separator/>
+                <filter string="De padres activos"
+                        name="padres_activos"
+                        domain="[('affiliate_ids.affiliate_type_id.name', '=', 'Activo')]"/>
+                <filter string="Discapacitados"
+                        name="discapacitados"
+                        domain="[('handicapped', '=', True)]"/>
+                <filter string="Verificados"
+                        name="verificados"
+                        domain="[('verified', '=', True)]"/>
+                <group expand="0" string="Agrupar por">
+                    <filter string="Nivel educativo"
+                            name="groupby_nivel"
+                            context="{'group_by': 'educational_level'}"/>
+                    <filter string="Departamento"
+                            name="groupby_departamento"
+                            context="{'group_by': 'affiliate_department_1'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <!-- ==================== PADRONES PREDEFINIDOS ==================== -->
+
+    <record id="action_padron_dia_del_padre" model="ir.actions.act_window">
+        <field name="name">Padrón Día del Padre</field>
+        <field name="res_model">affiliation.affiliate</field>
+        <field name="view_mode">tree,form</field>
+        <field name="view_id" ref="view_affiliate_tree"/>
+        <field name="search_view_id" ref="affiliate_active_search"/>
+        <field name="domain">[('parent_role', '=', 'father')]</field>
+        <field name="context">{'search_default_vigentes': 1}</field>
+    </record>
+
+    <record id="action_padron_dia_de_la_madre" model="ir.actions.act_window">
+        <field name="name">Padrón Día de la Madre</field>
+        <field name="res_model">affiliation.affiliate</field>
+        <field name="view_mode">tree,form</field>
+        <field name="view_id" ref="view_affiliate_tree"/>
+        <field name="search_view_id" ref="affiliate_active_search"/>
+        <field name="domain">[('parent_role', '=', 'mother')]</field>
+        <field name="context">{'search_default_vigentes': 1}</field>
+    </record>
+
+    <record id="action_padron_dia_del_nino" model="ir.actions.act_window">
+        <field name="name">Padrón Día del Niño</field>
+        <field name="res_model">affiliation.affiliate_child</field>
+        <field name="view_mode">tree</field>
+        <field name="view_id" ref="view_affiliate_child_tree_readonly"/>
+        <field name="search_view_id" ref="affiliate_child_padrones_search"/>
+        <field name="context">{'search_default_menores_13': 1, 'search_default_padres_activos': 1}</field>
+    </record>
+
+    <record id="action_padron_escolar" model="ir.actions.act_window">
+        <field name="name">Padrón Escolar</field>
+        <field name="res_model">affiliation.affiliate_child</field>
+        <field name="view_mode">tree</field>
+        <field name="view_id" ref="view_affiliate_child_tree_readonly"/>
+        <field name="search_view_id" ref="affiliate_child_padrones_search"/>
+        <field name="context">{'search_default_en_edad_escolar': 1, 'search_default_groupby_nivel': 1}</field>
+    </record>
+
+    <record id="action_padron_por_clases" model="ir.actions.act_window">
+        <field name="name">Padrón por Clases</field>
+        <field name="res_model">affiliation.affiliate</field>
+        <field name="view_mode">tree,form</field>
+        <field name="view_id" ref="view_affiliate_tree"/>
+        <field name="search_view_id" ref="affiliate_active_search"/>
+        <field name="context">{'search_default_vigentes': 1, 'search_default_groupby_clase': 1}</field>
+    </record>
+
+    <!-- ==================== MENÚ ==================== -->
+
+    <menuitem id="menu_padrones" name="Padrones"
+              parent="union_affiliation.union"
+              sequence="15"
+              groups="union_affiliation.group_affiliation_read"/>
+
+    <menuitem id="menu_padron_dia_del_padre" name="Día del Padre"
+              parent="menu_padrones" action="action_padron_dia_del_padre" sequence="10"/>
+    <menuitem id="menu_padron_dia_de_la_madre" name="Día de la Madre"
+              parent="menu_padrones" action="action_padron_dia_de_la_madre" sequence="20"/>
+    <menuitem id="menu_padron_dia_del_nino" name="Día del Niño"
+              parent="menu_padrones" action="action_padron_dia_del_nino" sequence="30"/>
+    <menuitem id="menu_padron_escolar" name="Escolar"
+              parent="menu_padrones" action="action_padron_escolar" sequence="40"/>
+    <menuitem id="menu_padron_por_clases" name="Por Clases"
+              parent="menu_padrones" action="action_padron_por_clases" sequence="50"/>
+</odoo>


### PR DESCRIPTION
## Qué

Tres mejoras del módulo de afiliación pedidas por el cliente:

1. **Padrones temáticos**: filtros y agrupaciones nuevos en la vista de base de datos de afiliados (padres/madres, jubilados, vigentes, por departamento/clase/tipo/rol) y una search view propia para hijos (menores de 13 por fecha de nacimiento, niveles escolares, de padres activos). Menú **Padrones** con los 5 listados recurrentes: Día del Padre, Día de la Madre, Día del Niño, Escolar (agrupado por nivel) y Por Clases.
2. **Eventos y asistencia digital** (`affiliation.event`): registro de asambleas/fiestas/elecciones con asistentes que se agregan buscando por apellido, legajo o DNI (reutiliza el `_name_search` del afiliado). Reemplaza el marcado a mano en planilla.
3. **Vista de bajas**: filtro "Dados de baja" + columnas opcionales de estado, fecha y motivo de baja en el mismo listado — equivale a la pestaña de históricos del Excel del cliente sin duplicar datos.

## Verificación

Probado con Playwright sobre la DB local: conteos exactos de cada padrón contra datos de prueba (incl. corte de edad por `context_today` y exclusión de hijos de jubilados en Día del Niño), alta de evento con búsqueda por legajo, y filtro de bajas devolviendo fecha y motivo.